### PR TITLE
add dropdown option to select number data type

### DIFF
--- a/src/Devbeat.DTE.JsonToCSharp.csproj
+++ b/src/Devbeat.DTE.JsonToCSharp.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DevToys.Api" Version="2.0.2-preview" />
+    <PackageReference Include="DevToys.Api" Version="2.0.8-preview" />
   </ItemGroup>
 
   <ItemGroup>
@@ -38,6 +38,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>JsonToCSharpExtension.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
   </ItemGroup>
 
 </Project>

--- a/src/JsonToCSharpExtension.Designer.cs
+++ b/src/JsonToCSharpExtension.Designer.cs
@@ -124,6 +124,15 @@ namespace Devbeat.DTE.JsonToCSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Number Type.
+        /// </summary>
+        internal static string NumberType {
+            get {
+                return ResourceManager.GetString("NumberType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to JSON &gt; C#.
         /// </summary>
         internal static string ShortDisplayTitle {

--- a/src/JsonToCSharpExtension.resx
+++ b/src/JsonToCSharpExtension.resx
@@ -138,6 +138,9 @@
   <data name="LongDisplayTitle" xml:space="preserve">
     <value>JSON &gt; C#</value>
   </data>
+  <data name="NumberType" xml:space="preserve">
+    <value>Number Type</value>
+  </data>
   <data name="ShortDisplayTitle" xml:space="preserve">
     <value>JSON &gt; C#</value>
   </data>

--- a/src/Models/NumberType.cs
+++ b/src/Models/NumberType.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Devbeat.DTE.JsonToCSharp.Models
+{
+    internal enum NumberType
+    {
+        Int,
+        Long,
+        Float,
+        Double,
+        Decimal
+    }
+
+    internal static class NumberTypeExtensions
+    {
+        public static string ToLowerString(this NumberType numberType)
+        {
+            return numberType.ToString().ToLower();
+        }
+    }
+}


### PR DESCRIPTION
Changes:
- Added missing `launchSettings.json` based on DevToys documentation.
- Updated conversion check order: 
  - Checks `string` type after `DateTime` and `Guid`
    - Extension was previously detecting json value `"12345"` as `int` when it should be of type `string`
  - Checks `int` before `long`
- Added drop down option to select numbers data type
  - Number selection is saved to SettingsProvider from DevToys so selection will be remembered.
  - The following data types are added:
    - `Int`
    - `Long`
    - `Float`
    - `Double`
    - `Decimal`
- Updated DevToy dependency to `2.0.8-preview`

Demo:
![2025-02-17_22-51-06](https://github.com/user-attachments/assets/bee5a576-aadf-405f-a243-ff7d3b537f17)
